### PR TITLE
Draft: Use enrollment pin

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,4 +40,4 @@ Remotes:
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -9,7 +9,7 @@ app_server = function(input, output, session) {
                              shiny::br(),
                              shiny::p("Waiting for brilliance...")))
   )
-  daily_enrollment = get_daily_enrollment(method="from_sql")
+  daily_enrollment = get_daily_enrollment(method="from_pin")
   admissions = utVizSunburst::admissions
 
   waiter::waiter_hide()

--- a/R/fct_get_data.R
+++ b/R/fct_get_data.R
@@ -22,7 +22,7 @@ get_daily_enrollment = function(method="from_rds") {
   else if (method == "from_pin") {
     pin_user = get_pin_user()
     board_rsc = pins::board_rsconnect()
-    enrollment_path = glue::glue("{pin_user}/enrollment")
+    enrollment_path = glue::glue("{pin_user}/daily_enrollment_pin")
     daily_enrollment_df = pins::pin_read(board_rsc, enrollment_path)
   }
   else {

--- a/R/fct_get_data.R
+++ b/R/fct_get_data.R
@@ -1,8 +1,14 @@
 #' Read daily enrollment from pin
 #'
 #' Read parsed daily enrollment from pin.
-#' Requires env var PIN_USER for path to data file
-#' called daily_enrollment.
+#' Requires env var `PIN_USER` for path to data file called `daily_enrollment_pin`.
+#'
+#' @param   method   Scalar character. Which method should be used for accessing the enrollment
+#' data? Valid choices: `from_rds` (the default; reads from a package-embedded dataset), `from_sql`
+#' (pulls from a database), `from_pin` (pulls from a pin-board on Posit connect).
+#'
+#' @return   data.frame containing the daily enrollment data.
+
 get_daily_enrollment = function(method="from_rds") {
 
   if (method == "from_sql") {
@@ -20,7 +26,7 @@ get_daily_enrollment = function(method="from_rds") {
     daily_enrollment_df = pins::pin_read(board_rsc, enrollment_path)
   }
   else {
-    stop("Method for gathering dialy enrollment data is not defined.")
+    stop("Method for gathering daily enrollment data is not defined.")
   }
   return(daily_enrollment_df)
 }

--- a/man/get_daily_enrollment.Rd
+++ b/man/get_daily_enrollment.Rd
@@ -6,8 +6,15 @@
 \usage{
 get_daily_enrollment(method = "from_rds")
 }
+\arguments{
+\item{method}{Scalar character. Which method should be used for accessing the enrollment
+data? Valid choices: `from_rds` (the default; reads from a package-embedded dataset), `from_sql`
+(pulls from a database), `from_pin` (pulls from a pin-board on Posit connect).}
+}
+\value{
+data.frame containing the daily enrollment data.
+}
 \description{
 Read parsed daily enrollment from pin.
-Requires env var PIN_USER for path to data file
-called daily_enrollment.
+Requires env var `PIN_USER` for path to data file called `daily_enrollment_pin`.
 }


### PR DESCRIPTION
`dsu-effectiveness/scheduled-pins` now has code for pushing a `daily_enrollment_pin` to the pin board on Connect.

The changes here aim to make use of that pin, rather than doing a database query for each app user.

Previously, get_daily_enrollment() was called with "from_sql" as argument (to pull data from the database). We have changed it to use "from_pin", and updated the name of the pin that data should be obtained from.

TODO: check that the `daily_enrollment_pin` requires a `{pin_user}` prefix.

Prerequisites:
- scheduled-pins must be redeployed using utPins >= v0.1.2
- daily_enrollment_pin must be successfully populated from scheduled pins